### PR TITLE
Update to solidity v.0.6.0

### DIFF
--- a/contracts/HitchensUnorderedAddressSet.sol
+++ b/contracts/HitchensUnorderedAddressSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1; 
+pragma solidity ^0.6.0; 
 
 /* 
 Hitchens UnorderedAddressSet v0.93
@@ -31,18 +31,19 @@ THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 */
 
 library HitchensUnorderedAddressSetLib {
-    
+
     struct Set {
         mapping(address => uint) keyPointers;
         address[] keyList;
     }
-    
+
     function insert(Set storage self, address key) internal {
         require(key != address(0), "UnorderedKeySet(100) - Key cannot be 0x0");
         require(!exists(self, key), "UnorderedAddressSet(101) - Address (key) already exists in the set.");
-        self.keyPointers[key] = self.keyList.push(key)-1;
+        self.keyList.push(key);
+        self.keyPointers[key] = self.keyList.length-1;
     }
-    
+
     function remove(Set storage self, address key) internal {
         require(exists(self, key), "UnorderedKeySet(102) - Address (key) does not exist in the set.");
         address keyToMove = self.keyList[count(self)-1];
@@ -50,22 +51,22 @@ library HitchensUnorderedAddressSetLib {
         self.keyPointers[keyToMove] = rowToReplace;
         self.keyList[rowToReplace] = keyToMove;
         delete self.keyPointers[key];
-        self.keyList.length--;
+        self.keyList.pop();
     }
-    
+
     function count(Set storage self) internal view returns(uint) {
         return(self.keyList.length);
     }
-    
+
     function exists(Set storage self, address key) internal view returns(bool) {
         if(self.keyList.length == 0) return false;
         return self.keyList[self.keyPointers[key]] == key;
     }
-    
+
     function keyAtIndex(Set storage self, uint index) internal view returns(address) {
         return self.keyList[index];
     }
-    
+
     function nukeSet(Set storage self) public {
         delete self.keyList;
     }

--- a/contracts/HitchensUnorderedKeySet.sol
+++ b/contracts/HitchensUnorderedKeySet.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.5.1; 
+pragma solidity ^0.6.0;
 
-/* 
+/*
 Hitchens UnorderedKeySet v0.93
 
 Library for managing CRUD operations in dynamic key sets.
@@ -31,18 +31,19 @@ THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 */
 
 library HitchensUnorderedKeySetLib {
-    
+
     struct Set {
         mapping(bytes32 => uint) keyPointers;
         bytes32[] keyList;
     }
-    
+
     function insert(Set storage self, bytes32 key) internal {
         require(key != 0x0, "UnorderedKeySet(100) - Key cannot be 0x0");
         require(!exists(self, key), "UnorderedKeySet(101) - Key already exists in the set.");
-        self.keyPointers[key] = self.keyList.push(key)-1;
+        self.keyList.push(key);
+        self.keyPointers[key] = self.keyList.length-1;
     }
-    
+
     function remove(Set storage self, bytes32 key) internal {
         require(exists(self, key), "UnorderedKeySet(102) - Key does not exist in the set.");
         bytes32 keyToMove = self.keyList[count(self)-1];
@@ -50,56 +51,56 @@ library HitchensUnorderedKeySetLib {
         self.keyPointers[keyToMove] = rowToReplace;
         self.keyList[rowToReplace] = keyToMove;
         delete self.keyPointers[key];
-        self.keyList.length--;
+        self.keyList.pop();
     }
-    
+
     function count(Set storage self) internal view returns(uint) {
         return(self.keyList.length);
     }
-    
+
     function exists(Set storage self, bytes32 key) internal view returns(bool) {
         if(self.keyList.length == 0) return false;
         return self.keyList[self.keyPointers[key]] == key;
     }
-    
+
     function keyAtIndex(Set storage self, uint index) internal view returns(bytes32) {
         return self.keyList[index];
     }
-    
+
     function nukeSet(Set storage self) public {
         delete self.keyList;
     }
 }
 
 contract HitchensUnorderedKeySet {
-    
+
     using HitchensUnorderedKeySetLib for HitchensUnorderedKeySetLib.Set;
     HitchensUnorderedKeySetLib.Set set;
-    
+
     event LogUpdate(address sender, string action, bytes32 key);
-    
+
     function exists(bytes32 key) public view returns(bool) {
         return set.exists(key);
     }
-    
+
     function insert(bytes32 key) public {
         set.insert(key);
         emit LogUpdate(msg.sender, "insert", key);
     }
-    
+
     function remove(bytes32 key) public {
         set.remove(key);
         emit LogUpdate(msg.sender, "remove", key);
     }
-    
+
     function count() public view returns(uint) {
         return set.count();
     }
-    
+
     function keyAtIndex(uint index) public view returns(bytes32) {
         return set.keyAtIndex(index);
     }
-    
+
     function nukeSet() public {
         set.nukeSet();
     }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,22 +1,22 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.6.0;
 
 /// @dev Stub for access control.
 
 contract Ownable {
-    
+
     address public owner;
-    
+
     modifier onlyOwner {
         require(msg.sender == owner);
         _;
     }
-    
+
     event LogNewOwner(address sender, address newOwner);
-    
+
     constructor() public {
         owner = msg.sender;
     }
-    
+
     function changeOwner(address newOwner) public onlyOwner {
         require(newOwner != address(0));
         emit LogNewOwner(msg.sender, newOwner);


### PR DESCRIPTION
Updates the library to work with Solidity v.0.6.0.
The following breaking changes affect the library and are taken from the [official documentation](https://solidity.readthedocs.io/en/latest/060-breaking-changes.html#).
-  Member-access to `length` of arrays is now always read-only, even for storage arrays. It is no longer possible to resize storage arrays assigning a new value to their length. Use `push()`, `push(value)` or `pop()` instead, or assign a full array, which will of course overwrite existing content. The reason behind this is to prevent storage collisions by gigantic storage arrays.
- The function `push(value)` for dynamic storage arrays does not return the new length anymore (it returns nothing).