### PR TITLE
feat: upgrade to solidity ^0.6.0

### DIFF
--- a/contracts/HitchensUnorderedAddressSet.sol
+++ b/contracts/HitchensUnorderedAddressSet.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.1; 
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
-/* 
+/*
 Hitchens UnorderedAddressSet v0.93
 
 Library for managing CRUD operations in dynamic address sets.
@@ -31,18 +32,19 @@ THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 */
 
 library HitchensUnorderedAddressSetLib {
-    
+
     struct Set {
         mapping(address => uint) keyPointers;
         address[] keyList;
     }
-    
+
     function insert(Set storage self, address key) internal {
         require(key != address(0), "UnorderedKeySet(100) - Key cannot be 0x0");
         require(!exists(self, key), "UnorderedAddressSet(101) - Address (key) already exists in the set.");
-        self.keyPointers[key] = self.keyList.push(key)-1;
+        self.keyList.push(key);
+        self.keyPointers[key] = self.keyList.length - 1;
     }
-    
+
     function remove(Set storage self, address key) internal {
         require(exists(self, key), "UnorderedKeySet(102) - Address (key) does not exist in the set.");
         address keyToMove = self.keyList[count(self)-1];
@@ -50,18 +52,18 @@ library HitchensUnorderedAddressSetLib {
         self.keyPointers[keyToMove] = rowToReplace;
         self.keyList[rowToReplace] = keyToMove;
         delete self.keyPointers[key];
-        self.keyList.length--;
+        self.keyList.pop();
     }
-    
+
     function count(Set storage self) internal view returns(uint) {
         return(self.keyList.length);
     }
-    
+
     function exists(Set storage self, address key) internal view returns(bool) {
         if(self.keyList.length == 0) return false;
         return self.keyList[self.keyPointers[key]] == key;
     }
-    
+
     function keyAtIndex(Set storage self, uint index) internal view returns(address) {
         return self.keyList[index];
     }

--- a/contracts/HitchensUnorderedKeySet.sol
+++ b/contracts/HitchensUnorderedKeySet.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.1; 
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
-/* 
+/*
 Hitchens UnorderedKeySet v0.93
 
 Library for managing CRUD operations in dynamic key sets.
@@ -31,18 +32,19 @@ THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 */
 
 library HitchensUnorderedKeySetLib {
-    
+
     struct Set {
         mapping(bytes32 => uint) keyPointers;
         bytes32[] keyList;
     }
-    
+
     function insert(Set storage self, bytes32 key) internal {
         require(key != 0x0, "UnorderedKeySet(100) - Key cannot be 0x0");
         require(!exists(self, key), "UnorderedKeySet(101) - Key already exists in the set.");
-        self.keyPointers[key] = self.keyList.push(key)-1;
+        self.keyList.push(key);
+        self.keyPointers[key] = self.keyList.length - 1;
     }
-    
+
     function remove(Set storage self, bytes32 key) internal {
         require(exists(self, key), "UnorderedKeySet(102) - Key does not exist in the set.");
         bytes32 keyToMove = self.keyList[count(self)-1];
@@ -50,52 +52,52 @@ library HitchensUnorderedKeySetLib {
         self.keyPointers[keyToMove] = rowToReplace;
         self.keyList[rowToReplace] = keyToMove;
         delete self.keyPointers[key];
-        self.keyList.length--;
+        self.keyList.pop();
     }
-    
+
     function count(Set storage self) internal view returns(uint) {
         return(self.keyList.length);
     }
-    
+
     function exists(Set storage self, bytes32 key) internal view returns(bool) {
         if(self.keyList.length == 0) return false;
         return self.keyList[self.keyPointers[key]] == key;
     }
-    
+
     function keyAtIndex(Set storage self, uint index) internal view returns(bytes32) {
         return self.keyList[index];
     }
-    
+
     function nukeSet(Set storage self) public {
         delete self.keyList;
     }
 }
 
 contract HitchensUnorderedKeySet {
-    
+
     using HitchensUnorderedKeySetLib for HitchensUnorderedKeySetLib.Set;
     HitchensUnorderedKeySetLib.Set set;
-    
+
     event LogUpdate(address sender, string action, bytes32 key);
-    
+
     function exists(bytes32 key) public view returns(bool) {
         return set.exists(key);
     }
-    
+
     function insert(bytes32 key) public {
         set.insert(key);
         emit LogUpdate(msg.sender, "insert", key);
     }
-    
+
     function remove(bytes32 key) public {
         set.remove(key);
         emit LogUpdate(msg.sender, "remove", key);
     }
-    
+
     function count() public view returns(uint) {
         return set.count();
     }
-    
+
     function keyAtIndex(uint index) public view returns(bytes32) {
         return set.keyAtIndex(index);
     }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,22 +1,23 @@
-pragma solidity 0.5.1;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
 /// @dev Stub for access control.
 
 contract Ownable {
-    
+
     address public owner;
-    
+
     modifier onlyOwner {
         require(msg.sender == owner);
         _;
     }
-    
+
     event LogNewOwner(address sender, address newOwner);
-    
+
     constructor() public {
         owner = msg.sender;
     }
-    
+
     function changeOwner(address newOwner) public onlyOwner {
         require(newOwner != address(0));
         emit LogNewOwner(msg.sender, newOwner);

--- a/contracts/exampleWidget.sol
+++ b/contracts/exampleWidget.sol
@@ -1,24 +1,25 @@
-pragma solidity 0.5.1;
+// SPDX-License-Identifier
+pragma solidity ^0.6.0;
 
 import "./HitchensUnorderedKeySet.sol";
 
 contract Widget {
-    
+
     using HitchensUnorderedKeySetLib for HitchensUnorderedKeySetLib.Set;
     HitchensUnorderedKeySetLib.Set widgetSet;
-    
+
     struct WidgetStruct {
         string name;
         bool delux;
         uint price;
     }
-    
+
     mapping(bytes32 => WidgetStruct) widgets;
-    
+
     event LogNewWidget(address sender, bytes32 key, string name, bool delux, uint price);
-    event LogUpdateWidget(address sender, bytes32 key, string name, bool delux, uint price);    
+    event LogUpdateWidget(address sender, bytes32 key, string name, bool delux, uint price);
     event LogRemWidget(address sender, bytes32 key);
-    
+
     function newWidget(bytes32 key, string memory name, bool delux, uint price) public {
         widgetSet.insert(key); // Note that this will fail automatically if the key already exists.
         WidgetStruct storage w = widgets[key];
@@ -27,7 +28,7 @@ contract Widget {
         w.price = price;
         emit LogNewWidget(msg.sender, key, name, delux, price);
     }
-    
+
     function updateWidget(bytes32 key, string memory name, bool delux, uint price) public {
         require(widgetSet.exists(key), "Can't update a widget that doesn't exist.");
         WidgetStruct storage w = widgets[key];
@@ -36,23 +37,23 @@ contract Widget {
         w.price = price;
         emit LogUpdateWidget(msg.sender, key, name, delux, price);
     }
-    
+
     function remWidget(bytes32 key) public {
         widgetSet.remove(key); // Note that this will fail automatically if the key doesn't exist
         delete widgets[key];
         emit LogRemWidget(msg.sender, key);
     }
-    
+
     function getWidget(bytes32 key) public view returns(string memory name, bool delux, uint price) {
         require(widgetSet.exists(key), "Can't get a widget that doesn't exist.");
         WidgetStruct storage w = widgets[key];
         return(w.name, w.delux, w.price);
     }
-    
+
     function getWidgetCount() public view returns(uint count) {
         return widgetSet.count();
     }
-    
+
     function getWidgetAtIndex(uint index) public view returns(bytes32 key) {
         return widgetSet.keyAtIndex(index);
     }


### PR DESCRIPTION
Changelog:

- Add a [SDPX license identifier](https://solidity.readthedocs.io/en/v0.6.10/layout-of-source-files.html#spdx-license-identifier)
- [x] Change `self.keyPointers[key] = self.keyList.push(key)-1;` to `self.keyList.push(key); self.keyPointers[key] = self.keyList.length - 1;`
Changelog:
- Change `self.keyList.length--` to `self.keyList.pop();`
- Remove the extra indent on blank lines

For reference, the [v0.6.0 breaking changes list](https://solidity.readthedocs.io/en/v0.6.10/060-breaking-changes.html).