### PR TITLE
Update to 0.8.4; optimize error handling for gas

### DIFF
--- a/contracts/HitchensUnorderedAddressSet.sol
+++ b/contracts/HitchensUnorderedAddressSet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.4;
 
 /*
 Hitchens UnorderedAddressSet v0.93
@@ -31,7 +31,11 @@ SOFTWARE.
 THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 */
 
-library HitchensUnorderedAddressSetLib {
+library HitchensUnorderedAddressSetLib {    
+
+    error UnorderedKeySet100AddressCannotBe0x0();
+    error UnorderedAddressSet101AddressAlreadyExistsInSet();
+    error UnorderedKeySet102AddressDoesNotExistInSet();
 
     struct Set {
         mapping(address => uint) keyPointers;
@@ -39,14 +43,20 @@ library HitchensUnorderedAddressSetLib {
     }
 
     function insert(Set storage self, address key) internal {
-        require(key != address(0), "UnorderedKeySet(100) - Key cannot be 0x0");
-        require(!exists(self, key), "UnorderedAddressSet(101) - Address (key) already exists in the set.");
+        if(key == address(0)) {
+            revert UnorderedKeySet100AddressCannotBe0x0();
+        }
+        if(exists(self, key)) {
+            revert UnorderedAddressSet101AddressAlreadyExistsInSet();
+        }
         self.keyList.push(key);
         self.keyPointers[key] = self.keyList.length - 1;
     }
 
     function remove(Set storage self, address key) internal {
-        require(exists(self, key), "UnorderedKeySet(102) - Address (key) does not exist in the set.");
+        if(!exists(self, key)) {
+            revert UnorderedKeySet102AddressDoesNotExistInSet();
+        }
         address keyToMove = self.keyList[count(self)-1];
         uint rowToReplace = self.keyPointers[key];
         self.keyPointers[keyToMove] = rowToReplace;
@@ -68,4 +78,3 @@ library HitchensUnorderedAddressSetLib {
         return self.keyList[index];
     }
 }
-

--- a/contracts/HitchensUnorderedKeySet.sol
+++ b/contracts/HitchensUnorderedKeySet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.4;
 
 /*
 Hitchens UnorderedKeySet v0.93
@@ -33,20 +33,30 @@ THIS SOFTWARE IS NOT TESTED OR AUDITED. DO NOT USE FOR PRODUCTION.
 
 library HitchensUnorderedKeySetLib {
 
+    error UnorderedKeySet100KeyCannotBe0x0();
+    error UnorderedKeySet101KeyAlreadyExistsInSet();
+    error UnorderedKeySet102KeyDoesNotExistInSet();
+
     struct Set {
         mapping(bytes32 => uint) keyPointers;
         bytes32[] keyList;
     }
 
     function insert(Set storage self, bytes32 key) internal {
-        require(key != 0x0, "UnorderedKeySet(100) - Key cannot be 0x0");
-        require(!exists(self, key), "UnorderedKeySet(101) - Key already exists in the set.");
+        if(key == 0x0) {
+            revert UnorderedKeySet100KeyCannotBe0x0();
+        }
+        if(exists(self, key)) {
+            revert UnorderedKeySet101KeyAlreadyExistsInSet();
+        }
         self.keyList.push(key);
         self.keyPointers[key] = self.keyList.length - 1;
     }
 
     function remove(Set storage self, bytes32 key) internal {
-        require(exists(self, key), "UnorderedKeySet(102) - Key does not exist in the set.");
+        if(!exists(self, key)) {
+            revert UnorderedKeySet102KeyDoesNotExistInSet();
+        }
         bytes32 keyToMove = self.keyList[count(self)-1];
         uint rowToReplace = self.keyPointers[key];
         self.keyPointers[keyToMove] = rowToReplace;
@@ -100,5 +110,9 @@ contract HitchensUnorderedKeySet {
 
     function keyAtIndex(uint index) public view returns(bytes32) {
         return set.keyAtIndex(index);
+    }
+
+    function stringToBytes(string memory _string) external pure returns (bytes32) {
+        return keccak256(abi.encode(_string));
     }
 }


### PR DESCRIPTION
I updated the Solidity version to 0.8.4, since this is the earliest version to support custom errors.

I have also updated the error from require, to revert with the new custom errors.

I believe this is beneficial, as it saves on gas, while still providing adequate error messages.